### PR TITLE
Make migration user configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,39 @@
 language: php
 
+sudo: false
+
+before_install: composer self-update
+
+install: composer update
+
 php:
   - 5.4
   - 5.5
   - 5.6
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 env:
   global:
     - TIMEZONE="Europe/Berlin"
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev --no-interaction
+  - echo 'date.timezone = "Europe/Berlin"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 script: vendor/bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+
+notifications:
+  email:
+    - jerome@kreait.com
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/81fafa2c4f2eb03e552e
+    on_success: change
+    on_failure: always
+    on_start: false

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,6 +44,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode( 'namespace' )->defaultValue( 'Application\Migrations' )->cannotBeEmpty()->end()
             ->scalarNode( 'table_name' )->defaultValue( 'ezmigration_versions' )->cannotBeEmpty()->end()
             ->scalarNode( 'name' )->defaultValue( 'Application Migrations' )->end()
+            ->scalarNode( 'ez_user' )->defaultValue( 'admin' )->cannotBeEmpty()->end()
             ->end();
 
         return $treeBuilder;

--- a/README.md
+++ b/README.md
@@ -80,7 +80,21 @@ Please have a look at the
 [official documentation](http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html)
 for further information.
 
-## Examples
+### Changing the current migration user during a migration
+
+You can change the current eZ Publish user inside a migration by issuing the following command:
+
+```php
+$this->changeMigrationUser('another_username');
+```
+
+and restore the default Migration user by using:
+
+```php
+$this->restoreDefaultMigrationUser();
+```
+
+## Usage examples
 
 See [Resources/doc/examples](Resources/doc/examples) for some usage examples.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ ezpublish_migrations:
     namespace: Application\Migrations
     table_name: ezmigration_versions
     name: Application Migrations
+    ez_user: admin
 ```
 
 ## Usage

--- a/Tests/DependencyInjection/EzPublishMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/EzPublishMigrationsExtensionTest.php
@@ -22,6 +22,7 @@ class EzPublishMigrationsExtensionTest extends TestCase
             'namespace' => $this->migrationsNamespace,
             'table_name' => 'ezmigration_versions',
             'name' => 'Application Migrations',
+            'ez_user' => $this->migrationUser,
         );
 
         foreach ( $checks as $key => $value )

--- a/Tests/Migrations/EzPublishMigrationTest.php
+++ b/Tests/Migrations/EzPublishMigrationTest.php
@@ -17,6 +17,37 @@ class EzPublishMigrationTest extends TestCase
      * @param string $direction "up" or "down"
      * @dataProvider directionProvider
      */
+    public function testGetMigrationUser($direction)
+    {
+        $versionString = $this->generateMigrationAndReturnVersionString();
+        $namespace = $this->container->getParameter( 'ezpublish_migrations.namespace' );
+        $config = $this->getSqliteConfiguration();
+
+        $fullClassName = $namespace . '\\Version'.$versionString;
+        $filePath = $this->container->getParameter( 'ezpublish_migrations.dir_name' ) . '/Version' . $versionString . '.php';
+
+        $this->assertTrue( $this->fs->exists( $filePath ) );
+
+        require $filePath;
+
+        $version = new Version( $config, $versionString, $fullClassName );
+
+        $migration = $version->getMigration();
+        if ( $migration instanceof ContainerAwareInterface )
+        {
+            $migration->setContainer( $this->container );
+        }
+
+        $version->execute( $direction, true );
+
+        $this->assertAttributeEquals($this->migrationUser, 'defaultMigrationUser', $migration);
+        $this->assertAttributeEquals($this->migrationUser, 'currentMigrationUser', $migration);
+    }
+
+    /**
+     * @param string $direction "up" or "down"
+     * @dataProvider directionProvider
+     */
     public function testMigration($direction)
     {
         $versionString = $this->generateMigrationAndReturnVersionString();

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -47,7 +47,15 @@ class TestCase extends \PHPUnit_Framework_TestCase
      */
     protected $application;
 
+    /**
+     * @var string
+     */
     protected $migrationsNamespace;
+
+    /**
+     * @var string
+     */
+    protected $migrationUser;
 
     protected function setUp()
     {
@@ -58,6 +66,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
         $uniqId = uniqid();
         $this->rootDir = __DIR__ . '/Temporary' . $uniqId;
         $this->migrationsNamespace = 'Kreait\EzPublish\MigrationsBundle\Tests\Temporary' . $uniqId;
+        $this->migrationUser = $uniqId;
 
         $this->extension = new EzPublishMigrationsExtension();
         $this->container = $this->getContainer();
@@ -70,6 +79,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
 
         $this->container->loadFromExtension( $this->extension->getAlias() );
         $this->container->setParameter( 'ezpublish_migrations.namespace', $this->migrationsNamespace );
+        $this->container->setParameter( 'ezpublish_migrations.ez_user', $this->migrationUser);
         $this->container->compile();
 
         $this->application = $this->getApplication();
@@ -115,11 +125,22 @@ class TestCase extends \PHPUnit_Framework_TestCase
     {
         $userService = \Mockery::mock( 'eZ\Publish\API\Repository\UserService' )
             ->shouldIgnoreMissing()
-            ->shouldReceive( 'loadUser' )
-            ->andReturn( \Mockery::mock( 'eZ\Publish\API\Repository\Values\User\User' ) )
+            ->shouldReceive( 'loadUserByLogin' )
+            ->andReturn( $this->getEzUser() )
             ->getMock();
 
         return $userService;
+    }
+
+    /**
+     * @return \Mockery\MockInterface|\eZ\Publish\API\Repository\Values\User\User
+     */
+    protected function getEzUser()
+    {
+        $user = \Mockery::mock( 'eZ\Publish\API\Repository\Values\User\User' )
+            ->shouldIgnoreMissing();
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Until now, the migration user was fixed to the user ID `14` (which is the ID of the default admin user), which could cause troubles when the default admin has been deleted or changed.

With this PR, it is possible to configure an additional `ez_user` parameter, which defaults do `admin` (the default admin user).

In addition to that, it is now also possible to change the current user during a migration with the commands

```php
$this->changeMigrationUser('another_username');
// ...
$this->restoreDefaultMigrationUser();
```

The README has been updated accordingly.

(closes #3)